### PR TITLE
feat: add accessible care carnival

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,11 +311,11 @@
 
             const eventsData = [
                 { date: '7月18日-12月31日', venue: '奇美醫院', time: '全天', title: '奇美暖心角', type: '設施', description: '奇美暖心角設於第二與第五醫療大樓二樓間，讓空橋廊道不再只是通行動線，而是轉化為一條連接身體與心靈兩端的過渡帶。整體視覺設計採用墨綠色調，象徵一片靜謐的林地，宛如醫療場域中的「低調療癒者」，在來去匆匆的腳步聲中，悄然打開一扇通往內心的門，這是一處不需語言也能傳遞溫度的場域。', participants: '教學部、醫教會醫學人文組、藥劑部、院長室研發組' },
-                { date: '11月1日', venue: '吳園', time: '09:00-12:00', title: '腦中風暨腦創傷病友會', type: '病友會', description: '提供病友與家屬交流平台，宣導預防與照護知識，包含有獎徵答、毛巾健康操、經驗分享等。', participants: '護理部、復健治療師、營養師、醫師、居家護理師、臨床護理師' },
                 { date: '11月1-16日', venue: '吳園', time: '全天', title: '吳園特展', type: '展覽', description: '以醫學人文為主軸，展出醫療人員與病人的真實故事、醫學文化藝術，奇美小螺絲大力量的企業文化，並介紹奇美深耕臺南在地，為鄉親創造群體價值。', participants: '醫學人文組、藥劑部、護理部、教學部、奇美人以及Family、奇美學員、深耕計劃裡聯盟夥伴機構' },
                 { date: '11月14-28日', venue: '奇美博物館', time: '全天', title: '布雷西亞廳特展', type: '展覽', description: '以年代為主軸，展示奇美醫院從創辦人夢想起源到今日深耕臺南的醫療設備與人員優化演進史。', participants: '院長室研發組、藥劑部、品管部、教學部、護理部、奇美人以及Family、奇美學員、深耕計劃裡聯盟夥伴機構' },
                 { date: '11月15日', venue: '奇美博物館', time: '全天', title: '感染管制會議、重症感染研討會', type: '研討會', description: '聚焦專業議題，探討最新的感染管制策略與重症感染治療方法，提升醫療品質。', participants: '品質管理部、感染管制中心、臺南市衛生局' },
                 { date: '11月16日', venue: '奇美博物館', time: '全天', title: '醫品&病安國際研討會', type: '研討會', description: '邀請國際專家分享，主題涵蓋Clean Care 2.0、公平醫療體系、跨專業合作全人照護與智慧醫療轉型。', participants: '品質管理部、感染管制中心、臺灣醫療品質協會、國際專家' },
+                { date: '11月21日', venue: '奇美醫院', location: '奇美醫院的國際會議廳', time: '下午', title: '友善醫療日嘉年華', type: '嘉年華', description: '歡迎來到友善醫療日嘉年華！這是一場充滿歡樂、學習與健康的盛會。<br>打造友善醫療，成就健康未來<br>Equitable care 公平照護確保人人都能獲得符合需求的、高品質的醫療，不因身份、背景、疾病或經濟狀況而受限。公平照護能提升整體醫療效益，縮小健康差距，建立社會對醫療體系的信任，並體現醫療的價值。而友善醫療更是實現公平照護的關鍵。讓我們攜手，用同理與尊重，共創一個更健康、更無礙的醫療環境！', participants: '全院同仁' },
                 { date: '11月22日', venue: '奇美博物館', time: '上午', title: '醫學人文沙龍 & AMEE心得分享', type: '沙龍', description: '小規模深度交流，探討醫學人文實踐，並分享國際醫學教育年會(AMEE)的最新趨勢與心得。', participants: 'Target Audience' },
                 { date: '11月22日', venue: '奇美博物館', time: '全天', title: '全職類PGY說明會暨現任PGY的IPE工作坊', type: '說明會暨工作坊', description: '旨在介紹奇美醫院PGY培訓計劃、福利與未來發展優勢，同時透過全職類PGY的參與，加強跨專業團隊照護的精神。落實IPE、IPP、TRM。同時也會透過不同職類的計劃介紹，強化尊重多元團隊文化。', participants: 'PGY成員、各科PGY負責人、教學部' },
                 { date: '11月22日', venue: '奇美博物館', time: '全天', title: 'YY Talk-2025 當代人物論壇', type: '論壇', description: '從不同領域職人分享，讓PGY學員看見多元職涯發展。同時透過邀請政院代表、市府代表、奇美博物館代表、醫療產業代表、AI產業代表、地方創生代表等知名人士的短講，探討次世代醫療與地方結合的跨域議題，並透過對話讓參與者思考如何永續健康照護的不同面向，同時如何創造群體健康價值來協助達成健康臺灣的願景', participants: '各職類PGY及PGY校友、院長室、教學部、奇美人以及Family' },
@@ -446,7 +446,7 @@
                         </div>
                         <div class="border-l-2 border-stone-200 pl-4 flex-grow">
                             <p class="font-bold text-lg text-[#3A3A3A]">${event.title}</p>
-                            <p class="text-sm text-gray-500">${event.venue} • ${event.time}</p>
+                            <p class="text-sm text-gray-500">${event.location || event.venue} • ${event.time}</p>
                         </div>
                         <div class="flex-shrink-0">
                            <span class="px-3 py-1 text-xs font-semibold text-white bg-[#A0522D] rounded-full">${event.type}</span>
@@ -532,7 +532,7 @@
                     const event = eventsData[eventIndex];
                     modalTitle.textContent = event.title;
                     modalDate.textContent = `日期: ${event.date} | 時間: ${event.time}`;
-                    modalVenue.textContent = `地點: ${event.venue}`;
+                    modalVenue.textContent = `地點: ${event.location || event.venue}`;
                     modalDescription.innerHTML = `<p>${event.description}</p>`;
                     modalParticipants.innerHTML = `<p class="font-bold mt-4 text-gray-800">主要參與單位/人員:</p><p class="text-gray-600">${event.participants}</p>`;
                     modal.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- add event data for Friendly Medical Day Carnival on Nov 21 at Chi Mei Hospital International Conference Hall
- remove Nov 1 stroke and brain injury patient meetup
- support optional detailed locations in timeline and event modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b9a751f8832695a9c66e71f8bc94