### PR TITLE
Update event descriptions and adjust YY Talk schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -317,7 +317,7 @@
                 { date: '11月16日', venue: '奇美博物館', time: '全天', title: '醫品&病安國際研討會', type: '研討會', description: '邀請國際專家分享，主題涵蓋Clean Care 2.0、公平醫療體系、跨專業合作全人照護與智慧醫療轉型。', participants: '品質管理部、感染管制中心、臺灣醫療品質協會、國際專家' },
                 { date: '11月21日', venue: '奇美醫院', location: '奇美醫院的國際會議廳', time: '下午', title: '友善醫療日嘉年華', type: '嘉年華', description: '歡迎來到友善醫療日嘉年華！這是一場充滿歡樂、學習與健康的盛會。<br>打造友善醫療，成就健康未來<br>Equitable care 公平照護確保人人都能獲得符合需求的、高品質的醫療，不因身份、背景、疾病或經濟狀況而受限。公平照護能提升整體醫療效益，縮小健康差距，建立社會對醫療體系的信任，並體現醫療的價值。而友善醫療更是實現公平照護的關鍵。讓我們攜手，用同理與尊重，共創一個更健康、更無礙的醫療環境！', participants: '全院同仁' },
                 { date: '11月22日', venue: '奇美博物館', time: '上午', title: '醫學人文沙龍 & AMEE心得分享', type: '沙龍', description: '小規模深度交流，探討醫學人文實踐，並分享國際醫學教育年會(AMEE)的最新趨勢與心得。', participants: 'Target Audience' },
-                { date: '11月22日', venue: '奇美博物館', time: '全天', title: '全職類PGY說明會暨現任PGY的IPE工作坊', type: '說明會暨工作坊', description: '旨在介紹奇美醫院PGY培訓計劃、福利與未來發展優勢，同時透過全職類PGY的參與，加強跨專業團隊照護的精神。落實IPE、IPP、TRM。同時也會透過不同職類的計劃介紹，強化尊重多元團隊文化。', participants: 'PGY成員、各科PGY負責人、教學部' },
+                { date: '11月22日', venue: '奇美博物館', location: '奇美博物館', time: '上午、下午', title: 'PGY說明會暨IPE工作坊', type: '說明會暨工作坊', description: '旨在介紹奇美醫院PGY培訓計劃、福利與未來發展優勢，同時透過多科部PGY的參與，加強跨專業團隊照護的精神。落實IPE、IPP、TRM。同時也會透過不同職類的計劃介紹，強化尊重多元團隊文化。', participants: 'PGY成員、各科PGY負責人、教學部' },
                 { date: '11月22日', venue: '奇美博物館', time: '全天', title: 'YY Talk-2025 當代人物論壇', type: '論壇', description: `
                     <p>從不同領域職人分享，讓PGY學員看見多元職涯發展。論壇邀請政院代表、市府代表、奇美博物館代表、醫療產業代表、AI產業代表、地方創生代表等知名人士的短講，探索次世代醫療與地方結合的跨域議題，並透過對話思考如何打造永續健康照護與群體健康價值。</p>
                     <div class="overflow-x-auto mt-6">
@@ -347,7 +347,7 @@
                                     <td class="px-3 py-2 border border-gray-200">致詞</td>
                                     <td class="px-3 py-2 border border-gray-200">總統府</td>
                                     <td class="px-3 py-2 border border-gray-200">賴清德 總統</td>
-                                    <td class="px-3 py-2 border border-gray-200" rowspan="3">歡迎</td>
+                                    <td class="px-3 py-2 border border-gray-200" rowspan="2">歡迎</td>
                                 </tr>
                                 <tr>
                                     <td class="px-3 py-2 border border-gray-200">10:10–10:20</td>
@@ -357,14 +357,7 @@
                                     <td class="px-3 py-2 border border-gray-200">黃偉哲 市長</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">10:20–10:30</td>
-                                    <td class="px-3 py-2 border border-gray-200">10</td>
-                                    <td class="px-3 py-2 border border-gray-200">致詞</td>
-                                    <td class="px-3 py-2 border border-gray-200">奇美文教基金會暨奇美博物館</td>
-                                    <td class="px-3 py-2 border border-gray-200">許家彰 館長</td>
-                                </tr>
-                                <tr>
-                                    <td class="px-3 py-2 border border-gray-200">10:30–10:50</td>
+                                    <td class="px-3 py-2 border border-gray-200">10:20–10:40</td>
                                     <td class="px-3 py-2 border border-gray-200">20</td>
                                     <td class="px-3 py-2 border border-gray-200">演講</td>
                                     <td class="px-3 py-2 border border-gray-200">總統府國策顧問暨健康臺灣推動聯盟</td>
@@ -372,35 +365,35 @@
                                     <td class="px-3 py-2 border border-gray-200" rowspan="5">智慧醫療與健康臺灣<br>大未來</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">10:50–11:10</td>
+                                    <td class="px-3 py-2 border border-gray-200">10:40–11:00</td>
                                     <td class="px-3 py-2 border border-gray-200">20</td>
                                     <td class="px-3 py-2 border border-gray-200">演講</td>
                                     <td class="px-3 py-2 border border-gray-200">衛生福利部</td>
                                     <td class="px-3 py-2 border border-gray-200">石崇良 部長</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">11:10–11:30</td>
+                                    <td class="px-3 py-2 border border-gray-200">11:00–11:20</td>
                                     <td class="px-3 py-2 border border-gray-200">20</td>
                                     <td class="px-3 py-2 border border-gray-200">演講</td>
                                     <td class="px-3 py-2 border border-gray-200">國家科學及技術委員會</td>
                                     <td class="px-3 py-2 border border-gray-200">吳誠文 主委</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">11:30–11:50</td>
+                                    <td class="px-3 py-2 border border-gray-200">11:20–11:40</td>
                                     <td class="px-3 py-2 border border-gray-200">20</td>
                                     <td class="px-3 py-2 border border-gray-200">演講</td>
                                     <td class="px-3 py-2 border border-gray-200">奇美醫療財團法人奇美醫院</td>
                                     <td class="px-3 py-2 border border-gray-200">林宏榮 院長</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">11:50–12:20</td>
+                                    <td class="px-3 py-2 border border-gray-200">11:40–12:10</td>
                                     <td class="px-3 py-2 border border-gray-200">30</td>
                                     <td class="px-3 py-2 border border-gray-200">沙龍對談</td>
                                     <td class="px-3 py-2 border border-gray-200">總統府 / 衛福部 / 國科會 / 奇美醫院</td>
                                     <td class="px-3 py-2 border border-gray-200">上述四位講者＋人物誌唐源駿創辦人</td>
                                 </tr>
                                 <tr>
-                                    <td class="px-3 py-2 border border-gray-200">12:20–13:20</td>
+                                    <td class="px-3 py-2 border border-gray-200">12:10–13:10</td>
                                     <td class="px-3 py-2 border border-gray-200">60</td>
                                     <td class="px-3 py-2 border border-gray-200">休息</td>
                                     <td class="px-3 py-2 border border-gray-200">—</td>
@@ -479,8 +472,8 @@
                     </div>
                 `, participants: '各職類PGY及PGY校友、院長室、教學部、奇美人以及Family' },
                 { date: '11月23日', venue: '奇美博物館', time: '上午', title: 'PGY回娘家與海外留學Faculty Club', type: '短講、沙龍', description: '強化奇美人的連結，促進與他院的經驗交流，強化學習動力，並收集PGY訓練計劃長期成果的反饋；透過出國多元進修的心得分享，提供PGY校友以及參與者思考多元職涯發展可能性，同時建立海外進修名人榜以及師生經驗分享平台，逐步建立多元專業人才庫。', participants: '海外進修Faculty成員、、各醫事職類校友、在地職人' },
-                { date: '11月23日', venue: '奇美博物館', time: '上午', title: 'AI應用於醫學教育研討會', type: '研討會', description: '決賽成果發表舞台，展示奇美將AI技術創新應用於醫學教育的優秀專案，體現數位賦能成果，同時透過與外院的創新教學交流，激發教學創新能力。', participants: '參賽團隊、外部專家團隊、AI Everywhere 小組、藥劑部、院長室研發組、教學部、品管部' },
-                { date: '11月23日', venue: '奇美博物館', time: '下午', title: '奇美醫學教育研討會暨共識營 workshop', type: '研討會、工作坊與共識營', description: '除了展現年度醫學教育成果，還包含專題演講(Lecture)與實作工作坊(Workshop)，並透過內、外部顧問以及國際學者的指導，深化國際學術交流，不斷精進奇美醫教品質，也凝聚內部教學共識，學習落地應用經驗與精進教育品質技巧。透過專題演講(Lecture)與實作工作坊(Workshop)，教學共識營與研討會緊緊相扣，共識內容將會在顧問指導下，聚焦2026年的年度教學目標與執行路徑，透過醫學教育的框架，逐步落實奇美醫教理念。', participants: '醫教委員、教學負責人、外部顧問、國外貴賓' },
+                { date: '11月23日', venue: '奇美博物館', time: '上午', title: 'AI數位賦能於醫學教育 (白手起家搭建系統網站)', type: '研討會', description: '內容：第一部分、奇美將AI技術創新應用於醫學教育的應用。工作坊：手把手帶學員上機實戰到有初步成品。', participants: '參賽團隊、外部專家團隊、AI Everywhere 小組、藥劑部、院長室研發組、教學部、品管部' },
+                { date: '11月23日', venue: '奇美博物館', time: '下午', title: '奇美醫學教育研討會暨共識營 workshop', type: '研討會、工作坊與共識營', description: '為搭配教學組織改組，今年專注在奇美醫學教育的願景對齊，以及各功能小組以及執行單位的醫學教育共識。預計進行專題演講、教學型主治醫師醫教計劃報告以及共識工作坊，最後進入年度目標報告。', participants: '醫教委員、教學負責人、外部顧問、國外貴賓' },
             ];
             
             const philosophyContainer = document.getElementById('philosophy-cards');


### PR DESCRIPTION
## Summary
- rename the PGY說明會 event and update its schedule details and description
- adjust the YY Talk agenda to remove a greeting slot and move the pre-lunch sessions earlier
- refresh AI workshop titles and descriptions for November 23 events

## Testing
- No tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e5ece79fcc8326be0d5f611a5ef2df